### PR TITLE
Feature stat breakpoint fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -489,6 +489,16 @@ $imgpath: '../node_modules/@uiowa/uids/src/assets/images';
   }
 }
 
+// Stat fix to avoid inconsistent stacking below container breakpoint.
+@media (max-width: 81.375em) and (min-width: 768px) {
+  .stat--horizontal:not(.element--flex-center) .stat__description {
+    flex-basis: 80%;
+  }
+  .stat--horizontal:not(.element--flex-center) .stat__content {
+    flex-basis: 80%;
+  }
+}
+
 .grid-panel__column-content-right.grid-panel__content, .grid-panel__column-content-left.grid-panel__content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# How to test

`yarn dev`

- Verify that breakpoint looks a little better as seen in screenshots below:

As the browser gets smaller, it should go from:

<img width="1299" alt="Screen Shot 2021-09-20 at 10 27 22 AM" src="https://user-images.githubusercontent.com/1036433/134031923-31e446c1-e5fb-4fff-8691-872d4e9475bd.png">

To:

<img width="1142" alt="Screen Shot 2021-09-20 at 10 27 29 AM" src="https://user-images.githubusercontent.com/1036433/134031956-d10442d1-bdc7-4e79-bb8f-cdaeee44a4ce.png">

Instead of:

https://github.com/uiowa/viewbook-law/issues/17